### PR TITLE
replace WEBrick to thin.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development do
   gem 'capistrano_colors'
   gem 'artii'
   gem 'capistrano_banner'
+  gem 'thin'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     coffee-script-source (1.3.3)
     columnize (0.3.6)
     commonjs (0.2.6)
+    daemons (1.1.9)
     database_cleaner (0.9.1)
     debugger (1.1.4)
       columnize (>= 0.3.1)
@@ -362,6 +363,10 @@ GEM
     term-ansicolor (1.0.7)
     therubyracer (0.10.2)
       libv8 (~> 3.3.10)
+    thin (1.5.0)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.16.0)
     tilt (1.3.3)
     treetop (1.4.11)
@@ -428,6 +433,7 @@ DEPENDENCIES
   simplecov
   sprockets!
   sprockets-rails!
+  thin
   turbolinks
   twitter-bootstrap-rails!
   uglifier (>= 1.0.3)


### PR DESCRIPTION
WEBrick自体の問題で、WEBrickでずっと起動してるとメモリリークして残念な感じなのと、レスポンス自体もthinの方が上なので。

abでのベンチも記載します。concurrencyを増やすとWEBrickのベンチが取れないので10にしてます。
## WEBrick

``` shell
 [maeda@webistrano ~]$ ab -n 1000 -c 10 http://maeda000.tokyo.pb:3000/
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking maeda000.tokyo.pb (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        WEBrick/1.3.1
Server Hostname:        maeda000.tokyo.pb
Server Port:            3000

Document Path:          /
Document Length:        102 bytes

Concurrency Level:      10
Time taken for tests:   21.842 seconds
Complete requests:      1000
Failed requests:        0
Write errors:           0
Non-2xx responses:      1000
Total transferred:      556000 bytes
HTML transferred:       102000 bytes
Requests per second:    45.78 [#/sec] (mean)
Time per request:       218.420 [ms] (mean)
Time per request:       21.842 [ms] (mean, across all concurrent requests)
Transfer rate:          24.86 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   1.2      1      19
Processing:    79  217 172.4    204    1860
Waiting:       79  216 172.4    203    1860
Total:         79  218 172.6    206    1862

Percentage of the requests served within a certain time (ms)
  50%    206
  66%    251
  75%    270
  80%    281
  90%    312
  95%    337
  98%    354
  99%   1628
 100%   1862 (longest request)
```
## thin

``` shell
[maeda@webistrano ~]$ ab -n 1000 -c 10 http://maeda000.tokyo.pb:3000/
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking maeda000.tokyo.pb (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        thin
Server Hostname:        maeda000.tokyo.pb
Server Port:            3000

Document Path:          /
Document Length:        102 bytes

Concurrency Level:      10
Time taken for tests:   10.348 seconds
Complete requests:      1000
Failed requests:        0
Write errors:           0
Non-2xx responses:      1003
Total transferred:      519554 bytes
HTML transferred:       102306 bytes
Requests per second:    96.64 [#/sec] (mean)
Time per request:       103.480 [ms] (mean)
Time per request:       10.348 [ms] (mean, across all concurrent requests)
Transfer rate:          49.03 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.5      1       4
Processing:    10  102  33.3     88     277
Waiting:       10   99  32.4     87     195
Total:         11  103  33.2     90     277

Percentage of the requests served within a certain time (ms)
  50%     90
  66%    103
  75%    131
  80%    135
  90%    158
  95%    164
  98%    175
  99%    196
 100%    277 (longest request)
```

機能面のpull reqでないのでrejectしてもらっても大丈夫です。
