### PR TITLE
Modified an argument for .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service-name: travis-ci
+service_name: travis-ci


### PR DESCRIPTION
I read https://coveralls.io/docs/api_reference and found the following argument different.
I replace HYPHEN with UNDERSCORE.
